### PR TITLE
Use an interface rather than concrete type for testing.T

### DIFF
--- a/replayer.go
+++ b/replayer.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"runtime"
-	"testing"
 
 	"github.com/google/martian/har"
 )
@@ -19,7 +18,7 @@ type replayer struct {
 	entries []*har.Entry
 }
 
-func newReplayer(t *testing.T) http.RoundTripper {
+func newReplayer(t TestingT) http.RoundTripper {
 	_, file, num, ok := runtime.Caller(2)
 	if !ok {
 		fmt.Printf("called from %s#%d\n", file, num)

--- a/watney.go
+++ b/watney.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"testing"
 )
 
 var gold bool
@@ -17,8 +16,12 @@ func init() {
 	flag.Parse()
 }
 
+type TestingT interface {
+	Fatal(args ...interface{})
+}
+
 // Configure reconfigures a given http.Client to use a fixture provided transport
-func Configure(tr http.RoundTripper, t *testing.T) http.RoundTripper {
+func Configure(tr http.RoundTripper, t TestingT) http.RoundTripper {
 	if gold {
 		return newRecorder(tr)
 	}


### PR DESCRIPTION
This is preventing me from using a spec runner as `*testing.T` isn't provided, but an implementation of it is